### PR TITLE
Send /cleanup response to private user chat instead of current chat.

### DIFF
--- a/src/Commands/AdminCommands/CleanupCommand.php
+++ b/src/Commands/AdminCommands/CleanupCommand.php
@@ -351,19 +351,13 @@ class CleanupCommand extends AdminCommand
     public function execute()
     {
         $message = $this->getMessage();
-        $chat_id = $message->getChat()->getId();
+        $user_id = $message->getFrom()->getId();
         $text    = $message->getText(true);
 
         $data = [
-            'chat_id'    => $chat_id,
+            'chat_id'    => $user_id,
             'parse_mode' => 'Markdown',
         ];
-
-        if (!$message->getChat()->isPrivateChat()) {
-            $data['text'] = '/cleanup command is only available in a private chat.';
-
-            return Request::sendMessage($data);
-        }
 
         $settings = $this->getSettings($text);
         $queries  = $this->getQueries($settings);


### PR DESCRIPTION
Added a new parameter to the `Command` class called `$private_only`.

Setting that to true and calling the respective command in a public chat does the following:
- Delete the public message
- Post a private message to the sender saying that the command works in private chats only. This message also contains the original command call, so that it can just be copy-pasted.

It would also be possible to simply overwrite the Update object to act as if the command was called from a private chat in the first place, but that might be pushing it.
What do you think?

Also, I haven't managed to get this to work for channels, not quite sure why, but the command doesn't have a message object in it, weirdly 😕